### PR TITLE
CORE-3739 Stopped using the development server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:14-stretch
 
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
-FROM node:10-alpine3.10
+FROM node:10
 
-WORKDIR /opt/referee
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
 
-# Other dependencies
-RUN apk add python make bash
+RUN mkdir -p /app
 
-COPY package.json yarn.lock lerna.json ./
+COPY . /app/referee
+WORKDIR /app/referee
 
-RUN yarn install
-RUN yarn bootstrap
+RUN sed -i '/proxy/d' /app/referee/packages/client/package.json
+RUN yarn install && yarn bootstrap && yarn build
 
-COPY . .
-
-RUN npm rebuild node-sass
-
+ENV PORT 3000
 EXPOSE 3000
-CMD yarn start
+
+CMD ["yarn", "server-start"]


### PR DESCRIPTION
Using this server the image now takes "only" 300MB of ram instead of a whopping 1.2 gigs. This change is compatible with the current nomad job so no changes there are needed :)